### PR TITLE
Handle Kwargs for BaseModel class

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -6,14 +6,35 @@ from datetime import datetime
 from uuid import uuid4
 
 
-class BaseModel():
+class BaseModel:
     """Creates an instance of base Model"""
 
-    def __init__(self):
-        """Instanciates the object"""
-        self.id = str(uuid4())
-        self.created_at = datetime.now()
-        self.updated_at = datetime.now()
+    def __init__(self, **kwargs):
+        """Instanciates the object with dict from kwargs if not empty
+        else define values
+        """
+        if kwargs:
+            for key, value in kwargs.items():
+                if key != '__class__':
+                    formatted_value = self.format_value(key, value)
+                    # makes the code more robust
+                    setattr(self, key, formatted_value)
+        else:
+            self.id = str(uuid4())
+            self.created_at = datetime.now()
+            self.updated_at = datetime.now()
+
+    def format_value(self, key, value):
+        """formats the value depending on expected type
+        before setting them if kwargs is not none
+        """
+        if key in ['created_at', 'updated_at']:
+            # dateutils for older python versions
+            return datetime.fromisoformat(value)
+        elif key == 'id':
+            return str(value)  # not neccessary just a precaution
+        else:
+            return value
 
     def __str__(self):
         """Prints a user friendly output"""

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -21,13 +21,13 @@ class TestBaseModel(unittest.TestCase):
         self.assertIsInstance(self.obj1, BaseModel)
         self.assertIsInstance(self.obj2, BaseModel)
 
-    # def test_Instanciation_with_kwargs(self):
-    #     """Test obj instanciation with kwargs key values"""
-    #     my_dict = self.obj1.to_dict()
-    #     obj3 = BaseModel(**my_dict)
-    #     self.assertIsInstance(obj3.id, str)
-    #     self.assertIsInstance(obj3.created_at, datetime)
-    #     self.assertIsInstance(obj3.updated_at, datetime)
+    def test_Instanciation_with_kwargs(self):
+        """Test obj instanciation with kwargs key values"""
+        my_dict = self.obj1.to_dict()
+        obj3 = BaseModel(**my_dict) #unpacking operator
+        self.assertIsInstance(obj3.id, str)
+        self.assertIsInstance(obj3.created_at, datetime)
+        self.assertIsInstance(obj3.updated_at, datetime)
 
     def test_id(self):
         """Test unique id creation"""

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -1,7 +1,7 @@
-"""Tests the Base class BaseModel and it functionalities"""
-from models.base_model import BaseModel
 import unittest
 from datetime import datetime
+
+from models.base_model import BaseModel
 
 
 class TestBaseModel(unittest.TestCase):
@@ -20,6 +20,14 @@ class TestBaseModel(unittest.TestCase):
         self.assertIsNotNone(self.obj2)
         self.assertIsInstance(self.obj1, BaseModel)
         self.assertIsInstance(self.obj2, BaseModel)
+
+    # def test_Instanciation_with_kwargs(self):
+    #     """Test obj instanciation with kwargs key values"""
+    #     my_dict = self.obj1.to_dict()
+    #     obj3 = BaseModel(**my_dict)
+    #     self.assertIsInstance(obj3.id, str)
+    #     self.assertIsInstance(obj3.created_at, datetime)
+    #     self.assertIsInstance(obj3.updated_at, datetime)
 
     def test_id(self):
         """Test unique id creation"""
@@ -52,13 +60,14 @@ class TestBaseModel(unittest.TestCase):
 
     def test_to_dict(self):
         """Test whether all instance key values are present
-         and in the right format"""
+        and in the right format"""
         my_dict = self.obj2.to_dict()
 
+        self.assertIsInstance(my_dict, dict)
         self.assertIsNotNone(my_dict)
-        self.assertIn('__class__', my_dict)
-        self.assertIsInstance(my_dict['created_at'], str)
-        self.assertIsInstance(my_dict['updated_at'], str)
+        self.assertIn("__class__", my_dict)
+        self.assertIsInstance(my_dict["created_at"], str)
+        self.assertIsInstance(my_dict["updated_at"], str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The following changes occurred:

- init in BaseModel was modified to handle  the case of instanciating a BaseModel object with the key values of kwargs.
-  A helper function `format_value` was implemented to format the keys, created_at and updated_at from `isoformat` strings back to datetime objects using `fromisoformat` method.
- Tests were initiated for the same and others were added for the to_save method